### PR TITLE
include issue

### DIFF
--- a/src/ofxShadowMap.cpp
+++ b/src/ofxShadowMap.cpp
@@ -1,8 +1,4 @@
 #include "ofxShadowMap.h"
-#include "ofLight.h"
-#include "ofMaterial.h"
-#include "ofGraphics.h"
-#include "glm/gtc/matrix_transform.hpp"
 
 bool ofxShadowMap::setup(int size, Resolution resolution){
 	bool success = writeMapShader.setupShaderFromSource(GL_VERTEX_SHADER,

--- a/src/ofxShadowMap.h
+++ b/src/ofxShadowMap.h
@@ -1,9 +1,6 @@
 #pragma once
 
-#include "ofConstants.h"
-#include "ofShader.h"
-#include "ofFbo.h"
-#include "ofParameter.h"
+#include "ofMain.h"
 
 class ofxShadowMap{
 public:


### PR DESCRIPTION
On Visual Studio 2017 with the release and the nightly builds.
Throws me : 'ofParameter<glm::quat>::Value::value' utiliza struct 'glm::tquat<float,0>' 
Solved it replacing the includes with the ofMain.h includes.


